### PR TITLE
Configure ghcr.io for container images

### DIFF
--- a/.github/workflows/controller-release.yaml
+++ b/.github/workflows/controller-release.yaml
@@ -1,0 +1,60 @@
+name: Release Controller
+
+on:
+  push:
+    tags:
+      - 'controller-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v1.14.0)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Facets-cloud/ingress-nginx'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/tags/controller-}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get go version
+        run: echo "GOLANG_VERSION=$(cat GOLANG_VERSION)" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push controller
+        run: |
+          make release
+        env:
+          REGISTRY: ghcr.io/facets-cloud/ingress-nginx
+          TAG: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.nginx == 'true')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Facets-cloud/ingress-nginx' && needs.changes.outputs.nginx == 'true')
     env:
       PLATFORMS: linux/amd64,linux/arm,linux/arm64
     steps:
@@ -185,9 +185,10 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build-image
         run: |
           export TAG=$(cat images/nginx/TAG)
-          cd images/nginx/rootfs && docker buildx build --platform=${{ env.PLATFORMS }} --push -t ingressnginx/nginx:${TAG} .
+          cd images/nginx/rootfs && docker buildx build --platform=${{ env.PLATFORMS }} --push -t ghcr.io/facets-cloud/ingress-nginx/nginx:${TAG} .

--- a/.github/workflows/zz-tmpl-images.yaml
+++ b/.github/workflows/zz-tmpl-images.yaml
@@ -58,7 +58,7 @@ jobs:
     name: Push
     needs: changestag
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'kubernetes/ingress-nginx' && needs.changestag.outputs.tag == 'true')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Facets-cloud/ingress-nginx' && needs.changestag.outputs.tag == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -72,10 +72,11 @@ jobs:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push
       run: |
-          cd images/ && make REGISTRY=ingressnginx NAME=${{ inputs.name }} push
+          cd images/ && make REGISTRY=ghcr.io/facets-cloud/ingress-nginx NAME=${{ inputs.name }} push
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ifneq ($(PLATFORM),)
 	PLATFORM_FLAG="--platform"
 endif
 
-REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images/ingress-nginx
+REGISTRY ?= ghcr.io/facets-cloud/ingress-nginx
 
 BASE_IMAGE ?= $(shell cat NGINX_BASE)
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -16,7 +16,7 @@ NAME ?=
 
 BUILDER ?= ingress-nginx
 PLATFORMS ?= linux/amd64,linux/arm,linux/arm64
-REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images/ingress-nginx
+REGISTRY ?= ghcr.io/facets-cloud/ingress-nginx
 IMAGE ?= $(REGISTRY)/$(NAME)
 TAG ?= $(shell cat $(NAME)/TAG)
 

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -14,7 +14,7 @@
 
 BUILDER ?= ingress-nginx
 PLATFORMS ?= linux/amd64,linux/arm,linux/arm64
-REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images/ingress-nginx
+REGISTRY ?= ghcr.io/facets-cloud/ingress-nginx
 IMAGE ?= $(REGISTRY)/nginx
 TAG ?= $(shell cat TAG)
 


### PR DESCRIPTION
## Summary

Configures GitHub Actions to build and publish container images to `ghcr.io/facets-cloud/ingress-nginx` instead of the upstream Kubernetes registries.

## Changes

- Update `REGISTRY` in Makefiles to point to ghcr.io
- Update `images.yaml` workflow for ghcr.io authentication and nginx image path
- Update `zz-tmpl-images.yaml` workflow for ghcr.io authentication
- Add `controller-release.yaml` workflow for controller image releases

## Images

After merge, the following images will be available:
- `ghcr.io/facets-cloud/ingress-nginx/nginx`
- `ghcr.io/facets-cloud/ingress-nginx/controller`
- `ghcr.io/facets-cloud/ingress-nginx/controller-chroot`

## Testing

After merge:
1. Trigger nginx image build (bump `images/nginx/TAG` or manual trigger)
2. Trigger controller release via `controller-release.yaml` workflow

Closes #2